### PR TITLE
Use identity labels for differentiating identities and detection

### DIFF
--- a/scripts/background-script.js
+++ b/scripts/background-script.js
@@ -172,7 +172,6 @@ function initSettings() {
   // get all accounts and identities from thunderbird
   messenger.accounts.list().then(
     (arrayMailAccounts) => {
-      console.log("arrayMailAccounts:", arrayMailAccounts);
       let iIndex = 0;
       for (var i in arrayMailAccounts) {
         // determine default identity of this account
@@ -195,8 +194,8 @@ function initSettings() {
         for (var j in arrayMailAccounts[i].identities) {
           // append account name in italics and in gray as in compose window
           const identity = arrayMailAccounts[i].identities[j];
-          var prettyName = identity.name + " <"+ identity.email + ">";
-          var prettyNameDebug = identity.email + " (account: " + arrayMailAccounts[i].name + ")";
+          var prettyName = `${identity.name} <${identity.email}>`;
+          var prettyNameDebug = `${identity.email} (account: ${arrayMailAccounts[i].name})`;
           accountsAndIdentities.identities[identity.id] = {
             email: identity.email,
             prettyName: prettyName,

--- a/scripts/background-script.js
+++ b/scripts/background-script.js
@@ -1,6 +1,6 @@
 var accountsAndIdentities = {
   accounts: {}, // key:id, values: prettyName, index, defaultIdentityId, type
-  identities: {}, // key:id, values: email, accountId, prettyName, prettyNameDebug
+  identities: {}, // key:id, values: email, accountId, prettyName, prettyNameDebug, label
 };
 
 var guiState = {
@@ -172,7 +172,7 @@ function initSettings() {
   // get all accounts and identities from thunderbird
   messenger.accounts.list().then(
     (arrayMailAccounts) => {
-      // console.log("arrayMailAccounts:", arrayMailAccounts);
+      console.log("arrayMailAccounts:", arrayMailAccounts);
       let iIndex = 0;
       for (var i in arrayMailAccounts) {
         // determine default identity of this account
@@ -194,15 +194,15 @@ function initSettings() {
 
         for (var j in arrayMailAccounts[i].identities) {
           // append account name in italics and in gray as in compose window
-          var prettyName = arrayMailAccounts[i].identities[j].name +
-                           " <"+ arrayMailAccounts[i].identities[j].email + ">";
-          var prettyNameDebug = arrayMailAccounts[i].identities[j].email +
-                                " (account: " + arrayMailAccounts[i].name + ")";
-          accountsAndIdentities.identities[arrayMailAccounts[i].identities[j].id] = {
-            email: arrayMailAccounts[i].identities[j].email,
+          const identity = arrayMailAccounts[i].identities[j];
+          var prettyName = identity.name + " <"+ identity.email + ">";
+          var prettyNameDebug = identity.email + " (account: " + arrayMailAccounts[i].name + ")";
+          accountsAndIdentities.identities[identity.id] = {
+            email: identity.email,
             prettyName: prettyName,
             prettyNameDebug : prettyNameDebug,
             accountId: arrayMailAccounts[i].id,
+            label: identity.label,
           };
         }
       }

--- a/scripts/background-script.js
+++ b/scripts/background-script.js
@@ -123,7 +123,7 @@ function checkSettings(inSettings) {
       is.detectable = true;
     }
     if (is.detectionAliases === undefined) {
-      is.detectionAliases = "";
+      is.detectionAliases = accountsAndIdentities.identities[idx].label;
     }
     if (is.warningAliases === undefined) {
       is.warningAliases = "";

--- a/scripts/options.js
+++ b/scripts/options.js
@@ -69,6 +69,7 @@ function fillSelectorList(elementId, toBeSelectedIdentityId) {
 
   let index = 0;
   for (var i in accountsAndIdentities.identities) {
+    const identity = accountsAndIdentities.identities[i];
     let opt = document.createElement("option");
     // accountLabel is the localised "account" text
     // identityLabel is the localised "identity" text
@@ -76,11 +77,14 @@ function fillSelectorList(elementId, toBeSelectedIdentityId) {
     let label1 = document.createElement("label");
     label1.className = "menu-iconic-text";
     label1.id = "labelIdentity"+i;
-    label1.textContent = accountsAndIdentities.identities[i].prettyName + " ";
+    label1.textContent = identity.prettyName + " ";
+    if (identity.label !== "") {
+        label1.textContent += `(${identity.label}) `;
+    }
     let label2 = document.createElement("label");
     label2.className = "menu-description";
     label2.id = "labelAccount"+i;
-    label2.textContent = accountsAndIdentities.accounts[accountsAndIdentities.identities[i].accountId].prettyName;
+    label2.textContent = accountsAndIdentities.accounts[identity.accountId].prettyName;
     opt.value = i;
     opt.appendChild(label1);
     opt.appendChild(label2);

--- a/scripts/options.js
+++ b/scripts/options.js
@@ -50,7 +50,7 @@ function getPerIdentitySettingsOrDefault(identityId) {
     // not found in settings, set defaults
     perIdentitySettings = {
       detectable: true,
-      detectionAliases: "",
+      detectionAliases: accountsAndIdentities[identityId].label,
       warningAliases: "",
     };
     settings.identitySettings[identityId] = perIdentitySettings;


### PR DESCRIPTION
Hi,

first thanks for the add-on it is very helpful for me. The changes in this PR are very helpful to how I use the add-on, but it may be to niche for general usage.

The use case is that I have identities that have the same name and mail address but differing Reply-To and standard copies. To differentiate them, I use the identity labels that are builtin in thunderbird. The add-on ignores those so far. This change adds them to the names of the different identities in the settings dropdown, enabling the user to differentiate them. 

Further, it sets the label as a default detection alias upon first creation. Hence, a good choice for a label allows both a nicer view and better default detection.

If a user does not use identity labels, this change has no effect for them.