### PR TITLE
Use Services global variable

### DIFF
--- a/scripts/exp_api.js
+++ b/scripts/exp_api.js
@@ -1,5 +1,4 @@
 let { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-let { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 
 let onRecipientsChangeHookInstalled = {};  // key: windowId; value: bool


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and experiments code doesn't have to import Services.jsm if the strict_min_version is 91.