### PR TITLE
Fix toRecipientsList and ccRecipientsList

### DIFF
--- a/scripts/background-script.js
+++ b/scripts/background-script.js
@@ -522,6 +522,8 @@ async function checkComposeTab(tab) {
       // check if recipients have changed
       if (JSON.stringify(allRecipientsList) != JSON.stringify(gcdAllRecipientsList)) {
         allRecipientsList = gcdAllRecipientsList;
+        toRecipientsList = gcd.to;
+        ccRecipientsList = gcd.cc;
         changed = true;
       }
     } else {

--- a/scripts/options.js
+++ b/scripts/options.js
@@ -138,7 +138,7 @@ function updateAdditionalHeaderFields() {
   let str = "";
   for (let i=0; i< settings.additionalHeaderFields.length; i++) {
     // key value
-    str = settings.additionalHeaderFields[i][0];
+    str += settings.additionalHeaderFields[i][0];
 
     // occurence value
     if (settings.additionalHeaderFields[i][1]) {


### PR DESCRIPTION
I found searchAndRemoveFromRecipientList() calls to remove sender address from recipients lists being ineffective because the toRecipientsList and ccRecipientsList were empty.

Fixed it by initializing the variables as early as possible.

Possibly also affects #37.