### PR TITLE
Further options

### DIFF
--- a/_locales/de-DE/messages.json
+++ b/_locales/de-DE/messages.json
@@ -70,6 +70,12 @@
   "CorrectIdentity.replyFromRecipient": {
     "message": "versuchen, die Identität zu suchen und zu benutzen, die in der Empfängerliste erscheint"
   },
+  "CorrectIdentity.keepRecipientAddress": {
+    "message": "keep the sender address that appears in its recipient list, even if it does not match the identity (e.g., for catch-all adresses)"
+  },
+  "CorrectIdentity.removeSenderFromRecipients": {
+    "message": "remove the identity from the recipient list"
+  },
   "CorrectIdentity.safetyCaption": {
     "message": "Sicherheit"
   },

--- a/_locales/en-US/messages.json
+++ b/_locales/en-US/messages.json
@@ -71,6 +71,12 @@
   "CorrectIdentity.replyFromRecipient": {
     "message": "attempt to find and use an identity that appears in its recipient list"
   },
+  "CorrectIdentity.keepRecipientAddress": {
+    "message": "keep the sender address that appears in its recipient list, even if it does not match the identity (e.g., for catch-all adresses)"
+  },
+  "CorrectIdentity.removeSenderFromRecipients": {
+    "message": "remove the identity from the recipient list"
+  },
   "CorrectIdentity.safetyCaption": {
     "message": "Safety"
   },

--- a/_locales/fr-FR/messages.json
+++ b/_locales/fr-FR/messages.json
@@ -47,6 +47,12 @@
   "CorrectIdentity.replyFromRecipient": {
     "message": "tenter de trouver et d’utiliser une identité qui apparaîtrait dans la liste des destinataires du message."
   },
+  "CorrectIdentity.keepRecipientAddress": {
+    "message": "keep the sender address that appears in its recipient list, even if it does not match the identity (e.g., for catch-all adresses)"
+  },
+  "CorrectIdentity.removeSenderFromRecipients": {
+    "message": "remove the identity from the recipient list"
+  },
   "CorrectIdentity.safetyCaption": {
     "message": "Sécurité"
   },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -47,6 +47,12 @@
   "CorrectIdentity.replyFromRecipient": {
     "message": "返信元のメッセージからアイデンティティの同一性を検出して適用する"
   },
+  "CorrectIdentity.keepRecipientAddress": {
+    "message": "keep the sender address that appears in its recipient list, even if it does not match the identity (e.g., for catch-all adresses)"
+  },
+  "CorrectIdentity.removeSenderFromRecipients": {
+    "message": "remove the identity from the recipient list"
+  },
   "CorrectIdentity.safetyCaption": {
     "message": "安全"
   },

--- a/_locales/nl-NL/messages.json
+++ b/_locales/nl-NL/messages.json
@@ -47,6 +47,12 @@
   "CorrectIdentity.replyFromRecipient": {
     "message": "detecteer en gebruik de identiteit die voorkomt in de ontvangerslijst"
   },
+  "CorrectIdentity.keepRecipientAddress": {
+    "message": "keep the sender address that appears in its recipient list, even if it does not match the identity (e.g., for catch-all adresses)"
+  },
+  "CorrectIdentity.removeSenderFromRecipients": {
+    "message": "remove the identity from the recipient list"
+  },
   "CorrectIdentity.safetyCaption": {
     "message": "Veiligheid"
   },

--- a/options.html
+++ b/options.html
@@ -102,6 +102,12 @@ textarea {
 		<div class="box">
 			<input type="checkbox" id="detectable" name="detectable"
 				value="detectable"> <label for="detectable">__MSG_CorrectIdentity.identityDetectable__</label><br>
+			<input type="checkbox"
+				id="removeSenderFromRecipients" name="removeSenderFromRecipients"
+				value="removeSenderFromRecipients"> <label for="removeSenderFromRecipients" id="removeSenderFromRecipientsLabel">__MSG_CorrectIdentity.removeSenderFromRecipients__</label><br>
+			<input type="checkbox"
+				id="keepRecipientAddress" name="keepRecipientAddress"
+				value="keepRecipientAddress"> <label for="keepRecipientAddress" id="keepRecipientAddressLabel">__MSG_CorrectIdentity.keepRecipientAddress__</label><br>
 		</div>
 		<label for="detectionAliases">__MSG_CorrectIdentity.aliasesDescription__</label>
 		<div class="tooltip">

--- a/scripts/background-script.js
+++ b/scripts/background-script.js
@@ -614,6 +614,18 @@ async function handleComposeTabChanged(tabId, initialIdentityId, currentIdentity
     try {
       let newIdentity = await messenger.identities.get(newIdentityId);
       let newIdentityEmail = newIdentity.email;
+
+      // Use custom original sender address if Identity Email is not equal to Original Recipient Email (first entry of the list)
+      let origRecipientEmail = origRecipientsList[0];
+      if (newIdentityEmail !== origRecipientEmail) {
+        console.log("newIdentityEmail: ", newIdentityEmail);
+        console.log("origRecipientEmail: ", origRecipientEmail);
+        console.log("Mismatch! Setting sender email to origRecipientEmail (" + origRecipientEmail + ")");
+        
+        details.from = newIdentity.name +' <'+ origRecipientEmail + '>';
+        newIdentityEmail = origRecipientEmail;
+      }
+
       if (searchAndRemoveFromRecipientList(composeTabStatus[tabId].toRecipientsList, newIdentityEmail)) {
         // found in "to"
         details.to = composeTabStatus[tabId].toRecipientsList;

--- a/scripts/background-script.js
+++ b/scripts/background-script.js
@@ -522,6 +522,8 @@ async function checkComposeTab(tab) {
       // check if recipients have changed
       if (JSON.stringify(allRecipientsList) != JSON.stringify(gcdAllRecipientsList)) {
         allRecipientsList = gcdAllRecipientsList;
+        toRecipientsList = gcd.to;
+        ccRecipientsList = gcd.cc;
         changed = true;
       }
     } else {

--- a/scripts/background-script.js
+++ b/scripts/background-script.js
@@ -528,8 +528,6 @@ async function checkComposeTab(tab) {
       // check if recipients have changed
       if (JSON.stringify(allRecipientsList) != JSON.stringify(gcdAllRecipientsList)) {
         allRecipientsList = gcdAllRecipientsList;
-        toRecipientsList = gcd.to;
-        ccRecipientsList = gcd.cc;
         changed = true;
       }
     } else {

--- a/scripts/options.js
+++ b/scripts/options.js
@@ -138,7 +138,7 @@ function updateAdditionalHeaderFields() {
   let str = "";
   for (let i=0; i< settings.additionalHeaderFields.length; i++) {
     // key value
-    str = settings.additionalHeaderFields[i][0];
+    str += settings.additionalHeaderFields[i][0];
 
     // occurence value
     if (settings.additionalHeaderFields[i][1]) {

--- a/scripts/options.js
+++ b/scripts/options.js
@@ -52,7 +52,8 @@ function getPerIdentitySettingsOrDefault(identityId) {
   if (perIdentitySettings === undefined) {
     // not found in settings, set defaults
     perIdentitySettings = {
-      detectable: true,
+      detectable, removeSenderFromRecipients: true,
+      keepRecipientAddress: false,
       detectionAliases: "",
       warningAliases: "",
     };
@@ -122,6 +123,10 @@ function updateGuiDetectionIdentityChanged(newDetectionIdentityId) {
 
   document.getElementById("detectable").checked =
     perIdentitySettings.detectable;
+  document.getElementById("removeSenderFromRecipients").checked =
+    perIdentitySettings.removeSenderFromRecipients;
+  document.getElementById("keepRecipientAddress").checked =
+    perIdentitySettings.keepRecipientAddress;
   document.getElementById("detectionAliases").value =
     perIdentitySettings.detectionAliases;
 }
@@ -242,6 +247,22 @@ function detectableChanged(result) {
   notifySettingsChanged();
 }
 
+function keepRecipientAddressChanged(result) {
+  let perIdentitySettings = getPerIdentitySettingsOrDefault(
+    guiState.currentDetectionIdentity
+  );
+  perIdentitySettings.keepRecipientAddress = result.target.checked;
+  notifySettingsChanged();
+}
+
+function removeSenderFromRecipientsChanged(result) {
+  let perIdentitySettings = getPerIdentitySettingsOrDefault(
+    guiState.currentDetectionIdentity
+  );
+  perIdentitySettings.removeSenderFromRecipients = result.target.checked;
+  notifySettingsChanged();
+}
+
 function detectionAliasesChanged(result) {
   let perIdentitySettings = getPerIdentitySettingsOrDefault(
     guiState.currentDetectionIdentity
@@ -298,6 +319,12 @@ function installConfigPageEventListners() {
   document
     .getElementById("detectable")
     .addEventListener("change", detectableChanged);
+  document
+    .getElementById("keepRecipientAddress")
+    .addEventListener("change", keepRecipientAddressChanged);
+  document
+    .getElementById("removeSenderFromRecipients")
+    .addEventListener("change", removeSenderFromRecipientsChanged);
   document
     .getElementById("detectionAliases")
     .addEventListener("change", detectionAliasesChanged);


### PR DESCRIPTION
Addition of two settings per identity:

1. Choice if the sender address shall be removed from the recipient lists (might also affect #37).
2. Choice to keep the original recipient address as sender address.
 
Remarks:
1. To not contradict with current behaviour, this setting is enabled by default - sender was tried to be removed in v2.4.1 already.
2. Disabled by default, though useful for catch-all identities: say you have a catch-all mailbox `foo@xyz.com` and also configured this as an identity in Thunderbird. Whenever you receive an email under `bar@xyz.com` or any other, you want to answer using the original recipient `bar@xyz.com` instead of `foo@xyz.com` or any manual fiddling with custom sender address in Thunderbird. You might want to add additional headers like `x-forwarded-for`, `x-rzg-fwd-by` or `x-envelope-to` to be able to detect newslist mails sent to those catch-all mailboxes.

Happy to discuss!

BTW: 2. was the functionality I missed in Thunderbird and found closest in Correct Identity. The only missing part was to setting the original recipient address as sender. The rest, what was already existing: Awesome! Great work!